### PR TITLE
bfg: update patch to cleanly apply to latest bfg

### DIFF
--- a/bfg/bfg.patch
+++ b/bfg/bfg.patch
@@ -194,13 +194,12 @@ diff --git a/bfg/src/test/scala/com/madgag/git/bfg/cli/MainSpec.scala b/bfg/src/
 index 794f13f..4e03cc7 100644
 --- a/bfg/src/test/scala/com/madgag/git/bfg/cli/MainSpec.scala
 +++ b/bfg/src/test/scala/com/madgag/git/bfg/cli/MainSpec.scala
-@@ -31,6 +31,7 @@ class MainSpec extends Specification {
+@@ -31,5 +31,6 @@ class MainSpec extends Specification {
  
    sequential // concurrent testing against scala.App is not safe https://twitter.com/rtyley/status/340376844916387840
  
 +/*
-   "CLI" should {
-     "not change commits unnecessarily" in new unpackedRepo("/sample-repos/exampleWithInitialCleanHistory.git.zip") {
+   "CLI" should "not change commits unnecessarily" in new unpackedRepo("/sample-repos/exampleWithInitialCleanHistory.git.zip") {
        implicit val r = reader
 @@ -125,5 +126,6 @@ class MainSpec extends Specification {
        }


### PR DESCRIPTION
With this update, the bfg patch will now apply cleanly to the latest bfg, which is at this commit on the master branch as of this writing:

https://github.com/rtyley/bfg-repo-cleaner/commit/aeee9e30e0a7ccb39cb916fb38179d612bfceb73

Since it may help with resolving #6, note that this has been tested on Debian 9 to get bfg building correctly with sbt per bfg's BUILD.md instructions, by installing sbt from its custom repo per the https://www.scala-sbt.org/download.html instructions.