### PR TITLE
readme: note sbt repo as not in Debian 9 (stable)

### DIFF
--- a/readme.org
+++ b/readme.org
@@ -27,7 +27,7 @@ For each module, its dependencies are documented in their corresponding readme.o
 
 * How to build
 
-- use sbt to compile the scala code
+- use sbt to compile the scala code (i.e. from https://www.scala-sbt.org/download.html repo)
 - use make to compile the C++ code
 - perl scripts can be run without compilation
 


### PR DESCRIPTION
It might not be obvious where the best place is to get sbt (and of the correct version), since it's not in the Debian main repository.  So we're adding this note to assist people who might be unsure of this (it may help with #6, for example) as we've tested some initial cregit builds using this method and it appears to work.