### PR TITLE
Update install

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,3 @@
 jars
-*/project/project
-*/target
+*project/project
+*target

--- a/.gitignore
+++ b/.gitignore
@@ -1,4 +1,3 @@
 jars
-*/project/build.properties
-*/project/
+*/project/project
 */target

--- a/persons/project/build.properties
+++ b/persons/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.7

--- a/readme.org
+++ b/readme.org
@@ -12,14 +12,22 @@
 
 * Prerequisites
 
-| srcml | http://www.srcml.org/                      | Make sure srcml is in the path    |
-| bfg   | https://github.com/rtyley/bfg-repo-cleaner | It needs to be patched. see below |
+| srcml | https://www.srcml.org/              | Make sure srcml is in path |
+| ctags | https://github.com/universal-ctags  | Make sure ctags is in path |
+| bfg   | https://github.com/dmgerman/bfg-repo-cleaner/tree/paul-blob-exec | 
 
 ** bfg
 
-1. you must fork bfg
-2. apply the patch found in the directory [[./bfg/readme.org][bfg]].
-3. build
+1. obtain above bfg branch
+#+BEGIN_SRC sh
+git clone https://github.com/dmgerman/bfg-repo-cleaner.git --branch paul-blob-exec
+#+END_SRC
+
+2. build in bfg root dir using
+#+BEGIN_SRC sh
+sbt
+> bfg/assembly
+#+END_SRC
 
 ** Dependencies:
 
@@ -27,8 +35,13 @@ For each module, its dependencies are documented in their corresponding readme.o
 
 * How to build
 
-- use sbt to compile the scala code
-- use make to compile the C++ code
+- compile slickGitLog, persons, remapCommits with sbt from their directories
+#+BEGIN_SRC sh
+sbt
+> one-jar
+#+END_SRC
+
+- use make to compile [[./tokenize/srcMLtoken][srcMLtoken]]
 - perl scripts can be run without compilation
 
 * How to use
@@ -51,14 +64,14 @@ Example:
 - tokenBySha.pl will execute 
 
 #+BEGIN_SRC sh
-./tokenizeSrcMl.pl --srcml2token=<path to srcml2token> --srcml=<path to srcml> --ctags=<path to ctags-exuberant>
+./tokenizeSrcMl.pl --srcml2token=<path to srcml2token> --srcml=<path to srcml> --ctags=<path to ctags>
 #+END_SRC
 
 Run it as:
 
 #+BEGIN_SRC sh
 export BFG_MEMO_DIR=/tmp/memo
-export BFG_TOKENIZE_CMD=/home/dmg/git.dmg/cregit-scala/tokenize/tokenizeSrcMl.pl --srcml2token=/home/dmg/git.dmg/cregit-scala/tokenize/srcMLtoken/srcml2token --srcml=srcml --ctags=ctags-exuberant
+export BFG_TOKENIZE_CMD=/home/dmg/git.dmg/cregit-scala/tokenize/tokenizeSrcMl.pl --srcml2token=/home/dmg/git.dmg/cregit-scala/tokenize/srcMLtoken/srcml2token --srcml=srcml --ctags=/usr/local/bin/ctags
 java -jar bfg-cregit.jar '--blob-exec:/home/dmg/git.dmg/cregit-scala/tokenizeByBlobId/tokenBySha.pl=.[ch]$' --no-blob-protection /path/repo
 #+END_SRC
 

--- a/readme.org
+++ b/readme.org
@@ -18,11 +18,11 @@
 
 ** bfg
 
-- obtain above bfg branch
+- obtain the above bfg branch
 #+BEGIN_SRC sh
 git clone https://github.com/dmgerman/bfg-repo-cleaner.git --branch paul-blob-exec
 #+END_SRC
-- build in bfg root dir using
+- build in the bfg root directory
 #+BEGIN_SRC sh
 sbt
 bfg/assembly
@@ -34,7 +34,7 @@ For each module, its dependencies are documented in their corresponding readme.o
 
 * How to build
 
-- compile slickGitLog, persons, remapCommits with sbt from their directories
+- compile slickGitLog, persons, remapCommits with sbt in their directories
 #+BEGIN_SRC sh
 sbt
 one-jar

--- a/readme.org
+++ b/readme.org
@@ -14,19 +14,18 @@
 
 | srcml | https://www.srcml.org/              | Make sure srcml is in path |
 | ctags | https://github.com/universal-ctags  | Make sure ctags is in path |
-| bfg   | https://github.com/dmgerman/bfg-repo-cleaner/tree/paul-blob-exec | 
+| bfg   | https://github.com/dmgerman/bfg-repo-cleaner/tree/paul-blob-exec | Download this branch |
 
 ** bfg
 
-1. obtain above bfg branch
+- obtain above bfg branch
 #+BEGIN_SRC sh
 git clone https://github.com/dmgerman/bfg-repo-cleaner.git --branch paul-blob-exec
 #+END_SRC
-
-2. build in bfg root dir using
+- build in bfg root dir using
 #+BEGIN_SRC sh
 sbt
-> bfg/assembly
+bfg/assembly
 #+END_SRC
 
 ** Dependencies:
@@ -38,9 +37,8 @@ For each module, its dependencies are documented in their corresponding readme.o
 - compile slickGitLog, persons, remapCommits with sbt from their directories
 #+BEGIN_SRC sh
 sbt
-> one-jar
+one-jar
 #+END_SRC
-
 - use make to compile [[./tokenize/srcMLtoken][srcMLtoken]]
 - perl scripts can be run without compilation
 

--- a/remapCommits/project/build.properties
+++ b/remapCommits/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.7

--- a/slickGitLog/.gitignore
+++ b/slickGitLog/.gitignore
@@ -1,2 +1,0 @@
-project/target
-target

--- a/slickGitLog/build.sbt
+++ b/slickGitLog/build.sbt
@@ -1,3 +1,7 @@
+import com.github.retronym.SbtOneJar._
+
+oneJarSettings
+
 
 libraryDependencies ++= Seq(
   "com.typesafe.slick" %% "slick" % "3.0.0",

--- a/slickGitLog/project/build.properties
+++ b/slickGitLog/project/build.properties
@@ -1,0 +1,1 @@
+sbt.version=0.13.7

--- a/slickGitLog/project/plugins.sbt
+++ b/slickGitLog/project/plugins.sbt
@@ -1,0 +1,2 @@
+addSbtPlugin("org.scala-sbt.plugins" % "sbt-onejar" % "0.8")
+


### PR DESCRIPTION
- Added build.properties to force intended sbt version when building (0.13.7) regardless of user's version
- Added missing one-jar dependency and plugin.sbt to slickGitLog
- changed .gitignore to include needed build.properties and plugins.sbt, it otherwise functions the same
- Updated readme build instructions, changed ctags-exuberant to ctags-universal