### PR TITLE
fix: update build configuration for modern environments

### DIFF
--- a/blameRepo/blameRepoFiles.pl
+++ b/blameRepo/blameRepoFiles.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/blameRepo/formatBlame.pl
+++ b/blameRepo/formatBlame.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/persons/build.sbt
+++ b/persons/build.sbt
@@ -4,14 +4,13 @@ oneJarSettings
 
 libraryDependencies ++= Seq(
   "com.typesafe.slick" %% "slick" % "3.0.0",
-  "org.xerial" % "sqlite-jdbc" % "3.8.0-SNAPSHOT",
+  "org.xerial" % "sqlite-jdbc" % "3.45.3.0",
   "com.zaxxer" % "HikariCP" % "2.4.1",
   "org.eclipse.jgit" % "org.eclipse.jgit" % "4.6.0.201612231935-r",
   "info.folone" %% "poi-scala" % "0.18"
 )
 
 resolvers ++= Seq(
-  "SQLite-JDBC Repository" at "https://oss.sonatype.org/content/repositories/snapshots",
-  "jgit-repo" at "http://download.eclipse.org/jgit/maven"
+  "jgit-repo" at "https://download.eclipse.org/jgit/maven"
 )
 

--- a/persons/project/build.properties
+++ b/persons/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.18

--- a/prettyPrint/prettyPrint-author.pl
+++ b/prettyPrint/prettyPrint-author.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/prettyPrint/prettyPrintFiles.pl
+++ b/prettyPrint/prettyPrintFiles.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/remapCommits/build.sbt
+++ b/remapCommits/build.sbt
@@ -5,13 +5,12 @@ oneJarSettings
 
 libraryDependencies ++= Seq(
   "com.typesafe.slick" %% "slick" % "3.0.0",
-  "org.xerial" % "sqlite-jdbc" % "3.8.0-SNAPSHOT",
+  "org.xerial" % "sqlite-jdbc" % "3.45.3.0",
   "com.zaxxer" % "HikariCP" % "2.4.1",
   "org.eclipse.jgit" % "org.eclipse.jgit" % "4.6.0.201612231935-r"
 )
 
 resolvers ++= Seq(
-  "SQLite-JDBC Repository" at "https://oss.sonatype.org/content/repositories/snapshots",
-  "jgit-repo" at "http://download.eclipse.org/jgit/maven"
+  "jgit-repo" at "https://download.eclipse.org/jgit/maven"
 )
 

--- a/remapCommits/project/build.properties
+++ b/remapCommits/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.18

--- a/slickGitLog/build.sbt
+++ b/slickGitLog/build.sbt
@@ -5,13 +5,12 @@ oneJarSettings
 
 libraryDependencies ++= Seq(
   "com.typesafe.slick" %% "slick" % "3.0.0",
-  "org.xerial" % "sqlite-jdbc" % "3.8.0-SNAPSHOT",
+  "org.xerial" % "sqlite-jdbc" % "3.45.3.0",
   "com.zaxxer" % "HikariCP" % "2.4.1",
   "org.eclipse.jgit" % "org.eclipse.jgit" % "4.6.0.201612231935-r"
 )
 
 resolvers ++= Seq(
-  "SQLite-JDBC Repository" at "https://oss.sonatype.org/content/repositories/snapshots",
-  "jgit-repo" at "http://download.eclipse.org/jgit/maven"
+  "jgit-repo" at "https://download.eclipse.org/jgit/maven"
 )
 

--- a/slickGitLog/project/build.properties
+++ b/slickGitLog/project/build.properties
@@ -1,1 +1,1 @@
-sbt.version=0.13.7
+sbt.version=0.13.18

--- a/tokenize/text/simpleTokenizer.pl
+++ b/tokenize/text/simpleTokenizer.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 use Text::ParseWords;
 

--- a/tokenize/tokenize.pl
+++ b/tokenize/tokenize.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tokenize/tokenizeSrcMl.pl
+++ b/tokenize/tokenizeSrcMl.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by

--- a/tokenizeByBlobId/tokenBySha.pl
+++ b/tokenizeByBlobId/tokenBySha.pl
@@ -1,4 +1,4 @@
-#!/usr/bin/perl
+#!/usr/bin/env perl
 
 # This program is free software: you can redistribute it and/or modify
 # it under the terms of the GNU General Public License as published by
@@ -118,7 +118,10 @@ if (-f $filename) {
     
 } else {
 
-  my ($fh, $file) = mkstemp( "tmpfile-in-XXXXX" );
+  # srcml 1.1.0 requires a file extension to parse source code correctly,
+  # even when --language is specified. Use SUFFIX so the temp file gets
+  # the original file's extension (e.g. .c or .h).
+  my ($fh, $file) = tempfile( "tmpfile-in-XXXXX", SUFFIX => ".$fileExt" );
   my ($fout, $outfile) = mkstemp( "tmpfile-out-XXXXX" );
 
   print $fh $contents;


### PR DESCRIPTION
Package versions were too old and some even unavailable and the change shebang `#!/usr/bin/pearl` to `#!/usr/bin/env pearl` to use environment resolved pearl.

- Use `#!/usr/bin/env perl` shebangs for portability across distros
- Replace sqlite-jdbc 3.8.0-SNAPSHOT with stable 3.45.3.0 (Sonatype snapshots repo no longer hosts it)
- Remove dead Sonatype snapshots resolver
- Switch jgit resolver from http:// to https://
- Upgrade sbt from 0.13.7 to 0.13.18 (fixes NoClassDefFoundError on modern JDKs)
- Fix tokenBySha.pl temp file to include file extension (required by srcml 1.1.0)

There should be some other adjustments in [bfg-repo-cleaner](https://github.com/rtyley/bfg-repo-cleaner) in order to make a build work, we will work to submit thoose changes later.

## Testing

We've tested this running for the [jq](https://github.com/jqlang/jq) source code. Bellow is an example image as evidence.

<img width="1668" height="912" alt="image" src="https://github.com/user-attachments/assets/6bf0391f-8222-4296-977c-594cedca3d18" />